### PR TITLE
Add SDL_TTF support for scalable TrueType fonts

### DIFF
--- a/.github/workflows/doit.yml
+++ b/.github/workflows/doit.yml
@@ -18,7 +18,7 @@ jobs:
         lfs: true
     - uses: msys2/setup-msys2@v2
       with:
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libpng mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-libzip mingw64/mingw-w64-x86_64-dwarfstack make zip
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libpng mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-libzip mingw64/mingw-w64-x86_64-dwarfstack make zip
     - run: make CC=gcc
     - run: make distrib
     - uses: softprops/action-gh-release@v1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEBUG=-gdwarf-4
 CFLAGS=$(OPT) $(DEBUG) -Wall -Wno-pointer-sign -Wno-char-subscripts -fno-omit-frame-pointer
 LDFLAGS=$(OPT) $(DEBUG) -Wl,-subsystem,windows
 
-LIBS = -lwsock32 -lws2_32 -lz -lpng -lsdl2 -lSDL2_mixer -lsdl2main -lzip -ldwarfstack
+LIBS = -lwsock32 -lws2_32 -lz -lpng -lsdl2 -lSDL2_mixer -lSDL2_ttf -lsdl2main -lzip -ldwarfstack
 
 OBJS	=		src/gui/gui.o src/client/client.o src/client/skill.o src/game/dd.o src/game/font.o\
 			src/game/main.o src/game/sprite.o src/game/game.o src/modder/modder.o\


### PR DESCRIPTION
Implemented TrueType font rendering using SDL_ttf as an alternative to the built-in bitmap fonts. When the -o GO_LARGE flag is used, the client will attempt to load system fonts (Arial on Windows, DejaVuSans on Linux, Helvetica on macOS) and render text with TTF at three sizes:
- Small: 10pt
- Medium: 14pt
- Large: 18pt

Benefits:
- Crisp, scalable text at any resolution
- Better readability for large displays
- Smooth anti-aliasing
- Graceful fallback to bitmap fonts if TTF unavailable

The system automatically tries multiple font paths for cross-platform compatibility and warns if fonts cannot be loaded.

Add SDL2_ttf dependency to build pipeline

Improves font loading and mouse input

Adds additional font paths for better cross-platform compatibility, including MSYS2 support and a local bundled font.