### PR TITLE
Switch to character literal for utf8 encodings

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -16,6 +16,7 @@
 #include "../../src/client.h"
 #include "../../src/client/_client.h"
 #include "../../src/sdl.h"
+#include "../../src/sdl/_sdl.h"
 #include "../../src/gui.h"
 #include "../../src/modder.h"
 
@@ -1265,7 +1266,7 @@ void cmd_text(char *text) {
 
     buf[0]=CL_TEXT;
 
-    for (len=0; text[len] && text[len]!='°' && len<254; len++) buf[len+2]=text[len];
+    for (len=0; text[len] && text[len]!=DDT && len<254; len++) buf[len+2]=text[len];
 
     buf[2+len]=0;
     buf[1]=len+1;

--- a/src/game/_game.h
+++ b/src/game/_game.h
@@ -21,7 +21,7 @@
 #define DD__SHADEFONT	128
 #define DD__FRAMEFONT	256
 
-#define DDT             '°' // draw text terminator - (zero stays one, too)
+#define DDT             '\xB0' // draw text terminator - (zero stays one, too)
 
 #define DL_STEP 128
 

--- a/src/game/dd.c
+++ b/src/game/dd.c
@@ -790,7 +790,7 @@ void dd_add_text(char *ptr) {
 
     while (*ptr) {
         while (*ptr==' ') ptr++;
-        while (*ptr=='°') {
+        while (*ptr==DDT) {
             ptr++;
             switch (*ptr) {
                 case 'c':	tmp=atoi(ptr+1);
@@ -807,7 +807,7 @@ void dd_add_text(char *ptr) {
         while (*ptr==' ') ptr++;
 
         n=0;
-        while (*ptr && *ptr!=' ' && *ptr!='°' && n<49) buf[n++]=*ptr++;
+        while (*ptr && *ptr!=' ' && *ptr!=DDT && n<49) buf[n++]=*ptr++;
         buf[n]=0;
 
         if (x+(tmp=dd_text_len(buf))>=TEXTDISPLAY_SX) {

--- a/src/gui/hover.c
+++ b/src/gui/hover.c
@@ -16,6 +16,7 @@
 #include "../../src/gui.h"
 #include "../../src/gui/_gui.h"
 #include "../../src/game.h"
+#include "../../src/game/_game.h"
 #include "../../src/client.h"
 #include "../../src/sdl.h"
 #include "../../src/modder.h"
@@ -81,7 +82,7 @@ static int textlength(char *text) {
     char *c,buf[4];
 
     for (x=0,c=text; *c; c++) {
-        if (c[0]=='°') {
+        if (c[0]==DDT) {
             if (c[1]=='c') {
                 if (isdigit(c[2])) {
                     if (isdigit(c[3])) {
@@ -104,7 +105,11 @@ int hover_capture_text(char *line) {
 
     while (isspace(*line)) line++;
 
-    if (strncmp(line,"°°°ITEMDESC",11)==0) {
+    if (line[0] == DDT &&
+        line[1] == DDT &&
+        line[2] == DDT &&
+        strncmp(line+3, "ITEMDESC", 8) == 0)
+      {
         last_invsel=atoi(line+11);
         if (last_invsel>=1000) last_invsel=last_invsel%1000+INVENTORYSIZE;
         if (last_invsel<0 || last_invsel>INVENTORYSIZE*2) {
@@ -117,11 +122,11 @@ int hover_capture_text(char *line) {
         return 1;
     }
 
-    if (line[0]=='°' && line[1]=='c' && line[2]=='5' && last_look) {
+    if (line[0]==DDT && line[1]=='c' && line[2]=='5' && last_look) {
         capture=1;
     }
 
-    if (line[0]=='°' && line[1]=='c' && line[2]=='5' && line[3]=='.') {
+    if (line[0]==DDT && line[1]=='c' && line[2]=='5' && line[3]=='.') {
         capture=last_look=0;
         last_right_click_invsel=-1;
         return 1;
@@ -204,7 +209,7 @@ static int display_hover(void) {
 
             for (i=0; hi[slot].desc[n][i]; i++) {
 
-                if (hi[slot].desc[n][i]=='°') {
+                if (hi[slot].desc[n][i]==DDT) {
                     if (hi[slot].desc[n][i+1]=='c') {
                         if (isdigit(hi[slot].desc[n][i+2])) {
                             if (hi[slot].desc[n][i+2]=='5') col=IRGB(31,31,31);

--- a/src/sdl/_sdl.h
+++ b/src/sdl/_sdl.h
@@ -78,7 +78,7 @@ struct ddfont {
 };
 #endif
 
-#define DDT             '°' // draw text terminator - (zero stays one, too)
+#define DDT             '\xB0' // draw text terminator - (zero stays one, too)
 
 int sdl_ic_load(int sprite);
 int sdl_pre_backgnd(void *ptr);


### PR DESCRIPTION
With latin1, the marker character of degree symbol does fit in a single byte, but it doesn't with utf8 encoding. This switches to hard coding the hex literal for the character, so it always fits regardless of whether latin1 or utf8 is used.

This used to be part of my linux branch, but this is code that both Eddow and myself wrote, so I pulled this commit out as a standalone PR that we can rebase both of our changes off of once merged