### PR TITLE
Fix password warning color using \xB0c3 for red text

### DIFF
--- a/src/gui/cmd.c
+++ b/src/gui/cmd.c
@@ -19,6 +19,8 @@
 #include "../../src/game.h"
 #include "../../src/modder.h"
 
+#define COLOR_RED "\xB0c3"
+
 #define MAXCMDLINE 199
 #define MAXHIST    20
 
@@ -161,7 +163,7 @@ int client_cmd(char *buf)
 		return 1;
 	}
 	if (strcasestr(buf, password)) {
-		addline("�c3Sorry, but you are not allowed to say your password. No matter what you're promised, do not give "
+		addline(COLOR_RED "Sorry, but you are not allowed to say your password. No matter what you're promised, do not give "
 		        "your password to anyone! The only things which happened to players who did are: Loss of all items, "
 		        "lots of negative experience, bad karma and locked characters. If you really, really think you have to "
 		        "tell your password to someone, then I'm sure you'll find a way around this block.");


### PR DESCRIPTION
fix issue#21 cmd.c line165 �->\xB0.
I can't test it in my own pc, make sure testing my fix code before you merge it.