### PR TITLE
Add macOS .app bundling and signed DMG releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install sdl2 sdl2_mixer libzip zlib
+          brew install sdl2 sdl2_mixer libzip zlib imagemagick
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,9 @@ jobs:
           retention-days: 7
 
   build-macos-release:
-    name: Build macOS Release
+    name: Build MacOS Release
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install sdl2 sdl2_mixer libzip zlib
+          brew install sdl2 sdl2_mixer libzip zlib imagemagick
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -148,7 +148,7 @@ jobs:
           cache: true
           cache-workspaces: astonia_net
 
-      - name: Build release
+      - name: Build release (moac + Rust lib)
         run: make macos
 
       - name: Strip debug symbols
@@ -156,15 +156,103 @@ jobs:
           strip bin/moac
           strip -x bin/libastonia_net.dylib
 
-      - name: Prepare distribution staging
-        run: make distrib-stage
+      # Build unsigned .app bundle
+      - name: Build .app bundle
+        run: make macos-appbundle
 
-      - name: Upload distribution staging
+      # Materialize the signing certificate from a base64-encoded secret
+      - name: Install signing certificate
+        run: |
+          mkdir -p certs
+          echo "${{ secrets.APPLE_CERT_P12 }}" | base64 --decode > certs/dist.p12
+
+      # Materialize the App Store Connect API key file in ./private_keys
+      # File name must match the api_key (KEY_ID) used later.
+      - name: Install App Store Connect API key
+        run: |
+          mkdir -p private_keys
+          echo '${{ secrets.APP_STORE_CONNECT_KEY }}' > "private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8"
+      
+      - name: Install App Store Connect API key JSON
+        run: |
+          echo '${{ secrets.APP_STORE_CONNECT_KEY_JSON }}' > private_keys/appstore_key.json
+
+      - name: Rename app with to tmp name
+        run: |
+          mv distrib/Astonia.app distrib/Astonia-unsigned.app
+
+      # 1) Sign app bundle
+      - name: Sign Astonia.app
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: distrib/Astonia-unsigned.app
+          output_path: distrib/Astonia.app
+
+          # Code signing certificate
+          p12_file: certs/dist.p12
+          p12_password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+
+          notarize: false
+          staple: false
+
+          rcodesign_version: 0.29.0
+
+          # Extra arguments passed directly to `rcodesign sign`
+          sign_args: |
+            --binary-identifier
+            com.prismaphonic.astonia
+            --for-notarization
+
+      - name: Remove unsigned app bundle
+        run: rm -rf distrib/Astonia-unsigned.app
+
+      # 2) Create an unsigned DMG wrapping the notarized .app
+      - name: Create unsigned DMG from notarized app
+        run: |
+          cd distrib
+          hdiutil create \
+            -volname "Astonia" \
+            -srcfolder "Astonia.app" \
+            -ov \
+            -format UDZO \
+            "Astonia-macOS-unsigned.dmg"
+          cd ..
+          ls -lh distrib/Astonia-macOS-unsigned.dmg
+
+      # 3) Sign + notarize + staple the DMG
+      - name: Sign, notarize, and staple DMG
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: distrib/Astonia-macOS-unsigned.dmg
+          output_path: distrib/Astonia-macOS.dmg
+
+          # Code signing certificate
+          p12_file: certs/dist.p12
+          p12_password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+
+          rcodesign_version: 0.29.0
+
+          sign_args: |
+            --for-notarization
+
+          # Notarization
+          notarize: true
+          staple: true
+          app_store_connect_api_key_json_file: private_keys/appstore_key.json
+          app_store_connect_api_issuer: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          app_store_connect_api_key: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+
+
+      - name: Remove unsigned DMG
+        run: rm -f distrib/Astonia-macOS-unsigned.dmg
+
+      - name: Upload signed DMG
         uses: actions/upload-artifact@v4
         with:
-          name: macos-staging
-          path: distrib/macos_client/
+          name: macos-dmg
+          path: distrib/Astonia-macOS.dmg
           retention-days: 7
+          if-no-files-found: error
 
   build-appimage-release:
     name: Build AppImage Release
@@ -216,11 +304,11 @@ jobs:
           name: windows-staging
           path: windows_client
 
-      - name: Download macOS staging
+      - name: Download macOS DMG
         uses: actions/download-artifact@v4
         with:
-          name: macos-staging
-          path: macos_client
+          name: macos-dmg
+          path: .
 
       - name: Download AppImage
         uses: actions/download-artifact@v4
@@ -231,14 +319,13 @@ jobs:
         run: |
           tar czf linux_client.tar.gz linux_client
           zip -q -r windows_client.zip windows_client
-          tar czf macos_client.tar.gz macos_client
 
       - name: Generate checksums
         run: |
           sha256sum linux_client.tar.gz > checksums.txt
           sha256sum windows_client.zip >> checksums.txt
-          sha256sum macos_client.tar.gz >> checksums.txt
           sha256sum astonia-client.AppImage >> checksums.txt
+          sha256sum Astonia-macOS.dmg >> checksums.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -246,8 +333,8 @@ jobs:
           files: |
             linux_client.tar.gz
             windows_client.zip
-            macos_client.tar.gz
             astonia-client.AppImage
+            Astonia-macOS.dmg
             checksums.txt
           draft: false
           prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,14 @@ macos:
 	@echo "Building for macOS..."
 	@$(MAKE) -f build/make/Makefile.macos
 
+macos-appbundle:
+	@echo "Building for macOS..."
+	@$(MAKE) -f build/make/Makefile.macos appbundle
+
+macos-signed-bundle:
+	@echo "Building (locally) signing bundle for macOS..."
+	@$(MAKE) -f build/make/Makefile.macos sign
+
 # Clean for all platforms
 clean:
 	@echo "Cleaning all platforms..."
@@ -185,4 +193,4 @@ docker-distrib-linux:
 # Include quality checks makefile (see build/make/Makefile.quality)
 include build/make/Makefile.quality
 
-.PHONY: all windows linux macos clean distrib distrib-stage amod convert anicopy zig-build docker-linux docker-windows docker-windows-dev docker-linux-dev docker-distrib-windows docker-distrib-linux appimage zen4-appimage sanitizer coverage
+.PHONY: all windows linux macos macos-appbundle macos-signed-bundle clean distrib distrib-stage amod convert anicopy zig-build docker-linux docker-windows docker-windows-dev docker-linux-dev docker-distrib-windows docker-distrib-linux appimage zen4-appimage sanitizer coverage

--- a/build/make/Makefile.macos
+++ b/build/make/Makefile.macos
@@ -55,6 +55,10 @@ else
 endif
 ASTONIA_NET_LIB=$(ASTONIA_NET_DIR)/target/$(ASTONIA_NET_TGT)/release/libastonia_net.dylib
 
+# Tiny Mach-O launcher used as CFBundleExecutable inside Astonia.app
+LAUNCHER_SRC := build/tools/macos_launcher.c
+LAUNCHER_BIN := bin/astonia_launcher
+
 OBJS	=		src/gui/gui_core.o src/gui/gui_input.o src/gui/gui_display.o src/gui/gui_inventory.o src/gui/gui_buttons.o src/gui/gui_map.o\
 			src/client/client.o src/client/protocol.o src/client/skill.o\
 			src/game/game_core.o src/game/game_effects.o src/game/game_lighting.o src/game/game_display.o\
@@ -74,6 +78,11 @@ bin/moac:	$(OBJS) $(ASTONIA_NET_LIB)
 $(ASTONIA_NET_LIB):
 		rustup target add $(ASTONIA_NET_TGT)
 		cd $(ASTONIA_NET_DIR) && cargo build --release --target $(ASTONIA_NET_TGT)
+
+# Build the tiny Mach-O launcher binary used as CFBundleExecutable
+$(LAUNCHER_BIN): $(LAUNCHER_SRC)
+		$(CC) -O2 -Wall -Wextra -mmacosx-version-min=11.0 \
+		      -o $(LAUNCHER_BIN) $(LAUNCHER_SRC)
 
 bin/amod.dylib:	src/amod/amod.o bin/moac
 		$(CC) $(LDFLAGS) -dynamiclib -undefined dynamic_lookup -o bin/amod.dylib src/amod/amod.o
@@ -143,7 +152,7 @@ clean:
 	@echo "Cleaning build artifacts..."
 	-rm -f src/*/*.o src/*/*-sanitizer.o src/*/*-coverage.o
 	-rm -f bin/moac bin/moac-sanitizer bin/moac-coverage
-	-rm -f bin/*.dylib bin/convert bin/anicopy
+	-rm -f bin/*.dylib bin/convert bin/anicopy bin/astonia_launcher
 	-rm -rf bin/*.dSYM
 	@echo "Cleaning coverage files..."
 	-find . -type f -name '*.gcda' -delete
@@ -187,3 +196,51 @@ distrib: distrib-stage
 amod:		bin/amod.dylib bin/moac
 convert:	bin/convert
 anicopy:	bin/anicopy
+
+# ---------------------------------------------------------------------------
+# macOS app bundle / signing (local)
+# ---------------------------------------------------------------------------
+
+MACOS_APP_BUNDLE       := distrib/Astonia.app
+MACOS_UNSIGNED_APP_TMP := distrib/Astonia-unsigned.app
+
+# Build the unsigned .app bundle.
+# Relies on:
+#   - bin/moac
+#   - bin/astonia_launcher
+appbundle: bin/moac $(LAUNCHER_BIN)
+	@echo "Building unsigned macOS .app bundle..."
+	@APP_VERSION=$(VERSION) build/tools/package_macos.sh
+
+sign: $(MACOS_APP_BUNDLE)
+	@echo "Signing macOS .app bundle with rcodesign..."
+	@[ -n "$$APPLE_CERT_P12" ] || { echo "ERROR: APPLE_CERT_P12 is not set"; exit 1; }
+	@[ -n "$$APPLE_CERT_P12_PASSWORD" ] || { echo "ERROR: APPLE_CERT_P12_PASSWORD is not set"; exit 1; }
+
+	@echo "Preparing unsigned bundle for signing..."
+	@rm -rf "$(MACOS_UNSIGNED_APP_TMP)"
+	@mv "$(MACOS_APP_BUNDLE)" "$(MACOS_UNSIGNED_APP_TMP)"
+
+	@echo "Running rcodesign (input: $(MACOS_UNSIGNED_APP_TMP), output: $(MACOS_APP_BUNDLE))..."
+	rcodesign sign \
+	  --p12-file "$$APPLE_CERT_P12" \
+	  --p12-password "$$APPLE_CERT_P12_PASSWORD" \
+	  --binary-identifier "com.prismaphonic.astonia" \
+      --for-notarization \
+	  "$(MACOS_UNSIGNED_APP_TMP)" \
+	  "$(MACOS_APP_BUNDLE)" \
+	|| { \
+	  echo "ERROR: rcodesign failed, restoring unsigned app bundle..."; \
+	  rm -rf "$(MACOS_APP_BUNDLE)"; \
+	  mv "$(MACOS_UNSIGNED_APP_TMP)" "$(MACOS_APP_BUNDLE)"; \
+	  exit 1; \
+	}
+
+	@echo "Cleaning up temporary unsigned bundle..."
+	@rm -rf "$(MACOS_UNSIGNED_APP_TMP)"
+
+	@echo "Signed app bundle at $(MACOS_APP_BUNDLE)"
+
+# Convenience: build + sign in one step
+appbundle-sign: appbundle sign
+	@echo "Signed app bundle at $(MACOS_APP_BUNDLE)"

--- a/build/tools/macos_launcher.c
+++ b/build/tools/macos_launcher.c
@@ -1,0 +1,60 @@
+// build/tools/macos_launcher.c
+// Tiny Mach-O launcher for Astonia.app
+//
+// Behavior:
+//   - Locates the .app bundle at runtime
+//   - cd's into Contents/Resources
+//   - execs ./bin/moac, forwarding all command-line args
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <limits.h>
+#include <string.h>
+#include <mach-o/dyld.h>
+
+int main(int argc, char **argv) {
+    char exe_path[PATH_MAX];
+    uint32_t size = sizeof(exe_path);
+
+    if (_NSGetExecutablePath(exe_path, &size) != 0) {
+        fprintf(stderr, "astonia launcher: _NSGetExecutablePath buffer too small\n");
+        return 1;
+    }
+
+    // exe_path -> .../Astonia.app/Contents/MacOS/astonia
+    // Get .../Astonia.app/Contents/MacOS
+    char *macos_dir = dirname(exe_path);
+    if (macos_dir == NULL) {
+        fprintf(stderr, "astonia launcher: dirname() failed\n");
+        return 1;
+    }
+
+    // chdir to Contents/MacOS
+    if (chdir(macos_dir) != 0) {
+        perror("astonia launcher: chdir to MacOS failed");
+        return 1;
+    }
+
+    // Then go up to Contents and into Resources:
+    //   Contents/MacOS -> Contents/Resources
+    if (chdir("../Resources") != 0) {
+        perror("astonia launcher: chdir to ../Resources failed");
+        return 1;
+    }
+
+    // Now CWD = .../Astonia.app/Contents/Resources
+    // We want to exec ./bin/moac from here.
+    //
+    // Reuse argv in-place:
+    //   argv[0] becomes "./bin/moac"
+    //   argv[1..] are forwarded unchanged
+    argv[0] = "./bin/moac";
+
+    execv(argv[0], argv);
+
+    // If we reach here, exec failed
+    perror("astonia launcher: execv ./bin/moac failed");
+    return 1;
+}

--- a/build/tools/package_macos.sh
+++ b/build/tools/package_macos.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+
+# Run from the project root, or via Makefile:
+#   APP_VERSION=1.2.3 build/tools/package_macos.sh
+#
+# This script:
+#   - Builds Astonia.app bundle structure
+#   - Copies bin/ and res/ into the bundle
+#   - Rewrites dylib dependencies and copies non-system dylibs into Resources/bin
+#   - Creates AppIcon.icns from res/moa3.ico
+#
+# It does NOT do any code signing. Use rcodesign (locally or in CI) to sign.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+APP_NAME="${APP_NAME:-Astonia Community Client}"
+APP_BUNDLE_NAME="${APP_BUNDLE_NAME:-Astonia.app}"
+BUNDLE_ID="${BUNDLE_ID:-com.prismaphonic.astonia}"
+APP_VERSION="${APP_VERSION:-1.0.0}"
+MIN_MACOS="${MIN_MACOS:-11.0}"
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BIN_DIR="$PROJECT_ROOT/bin"
+RES_DIR="$PROJECT_ROOT/res"
+
+DIST_DIR="$PROJECT_ROOT/distrib"
+APP_BUNDLE="$DIST_DIR/$APP_BUNDLE_NAME"
+APP_CONTENTS="$APP_BUNDLE/Contents"
+APP_MACOS="$APP_CONTENTS/MacOS"
+APP_RESOURCES="$APP_CONTENTS/Resources"
+APP_RES_BIN="$APP_RESOURCES/bin"
+APP_RES_RES="$APP_RESOURCES/res"
+
+INFO_PLIST="$APP_CONTENTS/Info.plist"
+PKGINFO_FILE="$APP_CONTENTS/PkgInfo"
+LAUNCHER="$APP_MACOS/astonia"
+
+if [[ ! -x "$BIN_DIR/moac" ]]; then
+  echo "ERROR: $BIN_DIR/moac not found (or not executable). Build the macOS binary first." >&2
+  exit 1
+fi
+
+if [[ ! -d "$RES_DIR" ]]; then
+  echo "ERROR: $RES_DIR not found. 'res' directory with assets is required." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+is_system_lib() {
+  local path="$1"
+  case "$path" in
+    /usr/lib/*|/System/*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# Recursively fix deps of a given Mach-O binary:
+# - Copy non-system dylibs into APP_RES_BIN
+# - Set their install_name id to @loader_path/<basename>
+# - Rewrite this binary's dep paths to @loader_path/<basename>
+fix_deps() {
+  local bin="$1"
+
+  echo "==> Fixing deps for $bin"
+  if ! otool -L "$bin" >/dev/null 2>&1; then
+    echo "    (warning: $bin is not a valid Mach-O or otool failed, skipping deps)" >&2
+    return
+  fi
+
+  # otool -L output: first line is the binary itself, skip it.
+  otool -L "$bin" | tail -n +2 | awk '{print $1}' | while read -r dep; do
+    [[ -z "$dep" ]] && continue
+
+    # Skip already-relative entries
+    case "$dep" in
+      @*) continue ;;
+    esac
+
+    # Skip system libs
+    if is_system_lib "$dep"; then
+      continue
+    fi
+
+    local base dest new_ref
+    base="$(basename "$dep")"
+    dest="$APP_RES_BIN/$base"
+    new_ref="@loader_path/$base"
+
+    # Copy dep if not already in our bundle
+    if [[ ! -f "$dest" ]]; then
+      echo "==>   Copying $dep -> $dest"
+      cp "$dep" "$dest"
+
+      echo "==>   Setting install_name id on $dest -> $new_ref"
+      install_name_tool -id "$new_ref" "$dest" || true
+
+      # Recurse into this dylib's deps
+      fix_deps "$dest"
+    fi
+
+    echo "==>   Rewriting dep in $bin: $dep -> $new_ref"
+    install_name_tool -change "$dep" "$new_ref" "$bin" || true
+  done
+}
+
+make_icns_from_ico() {
+  local ICO_IN="$1"           # e.g. res/moa3.ico (inside bundle)
+  local ICNS_OUT="$2"         # e.g. Astonia.icns
+  local TMP_ICONSET
+  TMP_ICONSET="$(mktemp -d /tmp/astonia-iconset.XXXXXX)"
+
+  echo "==> Building .icns from $ICO_IN -> $ICNS_OUT"
+
+  if ! command -v convert >/dev/null 2>&1; then
+    echo "ERROR: 'convert' (ImageMagick) not found. Install via 'brew install imagemagick'." >&2
+    rm -rf "$TMP_ICONSET"
+    return 1
+  fi
+
+  local BASE_PNG="$TMP_ICONSET/base.png"
+  convert "$ICO_IN[0]" "$BASE_PNG"
+
+  if ! command -v sips >/dev/null 2>&1; then
+    echo "ERROR: 'sips' not found (it should be present on macOS)." >&2
+    rm -rf "$TMP_ICONSET"
+    return 1
+  fi
+
+  resize_icon() {
+    local SIZE="$1"      # logical size (16, 32, 64, 128, 256, 512)
+    local SCALE="$2"     # 1 or 2
+    local NAME="$3"      # icon_16x16.png, icon_16x16@2x.png, etc.
+    local PIXELS
+    PIXELS=$(( SIZE * SCALE ))
+    sips -z "$PIXELS" "$PIXELS" "$BASE_PNG" --out "$TMP_ICONSET/$NAME" >/dev/null
+  }
+
+  # 16x16
+  resize_icon 16 1 icon_16x16.png
+  resize_icon 16 2 icon_16x16@2x.png
+  # 32x32
+  resize_icon 32 1 icon_32x32.png
+  resize_icon 32 2 icon_32x32@2x.png
+  # 128x128
+  resize_icon 128 1 icon_128x128.png
+  resize_icon 128 2 icon_128x128@2x.png
+  # 256x256
+  resize_icon 256 1 icon_256x256.png
+  resize_icon 256 2 icon_256x256@2x.png
+  # 512x512
+  resize_icon 512 1 icon_512x512.png
+  resize_icon 512 2 icon_512x512@2x.png
+
+  local ICONSET_DIR="${TMP_ICONSET%.XXXXXX}.iconset"
+  mv "$TMP_ICONSET" "$ICONSET_DIR"
+
+  if ! command -v iconutil >/dev/null 2>&1; then
+    echo "ERROR: 'iconutil' not found (should be on macOS with Xcode tools)." >&2
+    rm -rf "$ICONSET_DIR"
+    return 1
+  fi
+
+  iconutil -c icns "$ICONSET_DIR" -o "$ICNS_OUT"
+  rm -rf "$ICONSET_DIR"
+
+  echo "==> Created $ICNS_OUT"
+}
+
+# ---------------------------------------------------------------------------
+# Bundle skeleton
+# ---------------------------------------------------------------------------
+
+echo "Building macOS .app bundle (UNSIGNED)..."
+echo "  Project root:  $PROJECT_ROOT"
+echo "  App bundle:    $APP_BUNDLE"
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_MACOS" "$APP_RES_BIN" "$APP_RES_RES"
+
+# Info.plist
+cat > "$INFO_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleDisplayName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_ID}</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
+  <key>CFBundleVersion</key>
+  <string>${APP_VERSION}</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${APP_VERSION}</string>
+  <key>CFBundleExecutable</key>
+  <string>astonia</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>${MIN_MACOS}</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+# PkgInfo
+echo "APPL????" > "$PKGINFO_FILE"
+
+# ---------------------------------------------------------------------------
+# Copy bin/ and res/ into Resources
+# ---------------------------------------------------------------------------
+
+echo "==> Copying bin/ and res/ into bundle Resources"
+cp -R "$BIN_DIR"/. "$APP_RES_BIN/"
+cp -R "$RES_DIR"/. "$APP_RES_RES/"
+
+# Build .icns from our ICO and place it in Resources
+if [[ -f "$APP_RES_RES/moa3.ico" ]]; then
+  make_icns_from_ico "$APP_RES_RES/moa3.ico" "$APP_RESOURCES/AppIcon.icns" || true
+  rm -f "$APP_RES_RES/moa3.ico"
+fi
+
+# Remove any dSYM directories
+find "$APP_RES_BIN" -name "*.dSYM" -exec rm -rf {} + 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Launcher binary (Contents/MacOS/astonia)
+# ---------------------------------------------------------------------------
+
+LAUNCHER_SRC_BIN="$BIN_DIR/astonia_launcher"
+
+if [[ ! -x "$LAUNCHER_SRC_BIN" ]]; then
+  echo "ERROR: $LAUNCHER_SRC_BIN not found (or not executable). Build the macOS launcher first." >&2
+  exit 1
+fi
+
+cp "$LAUNCHER_SRC_BIN" "$LAUNCHER"
+chmod +x "$LAUNCHER"
+
+# ---------------------------------------------------------------------------
+# Rewrite dependencies & copy non-system dylibs
+# ---------------------------------------------------------------------------
+
+MOAC_BIN="$APP_RES_BIN/moac"
+ASTONIA_NET_BIN="$APP_RES_BIN/libastonia_net.dylib"
+
+if [[ ! -x "$MOAC_BIN" ]]; then
+  echo "ERROR: Expected $MOAC_BIN inside bundle, but it is missing or not executable." >&2
+  exit 1
+fi
+
+echo "==> Fixing dylib dependencies (recursive)..."
+fix_deps "$MOAC_BIN"
+
+if [[ -f "$ASTONIA_NET_BIN" ]]; then
+  fix_deps "$ASTONIA_NET_BIN"
+fi
+
+echo "==> macOS .app bundle built (UNSIGNED):"
+echo "    $APP_BUNDLE"


### PR DESCRIPTION
## Summary

This PR adds a macOS packaging + signing + notarization flow, aligned between local builds and CI.

## Changes

- Add `build/tools/package_macos.sh` to:
  - Build a proper `Astonia.app` bundle layout
  - Copy `bin/` and `res/` into `Contents/Resources/bin` and `Contents/Resources/res`
  - Rewrite non-system dylib deps into `@loader_path/...` and bundle them
  - Convert `res/moa3.ico` → `AppIcon.icns` for macOS

- Add a tiny native macOS launcher (`build/tools/macos_launcher.c`) that:
  - Resolves its own path
  - cd's into `Contents/Resources`
  - Executes `./moac` with the original `argv` so assets under `res/` are found correctly
  - This is required so that the entrypoint itself is signed (we can only codesign binaries, not bash scripts)

- Extend the macOS Makefile:
  - `make macos-appbundle` builds an unsigned `.app` bundle
  - `make macos-signed-bundle` uses `rcodesign` + a local `.p12` to produce a signed bundle
    - Uses `Developer ID Application` certificate
    - Sets hardened runtime via code-signature flags (required for notarization)

- Update `release.yml` macOS job to:
  - Build and strip the macOS binaries
  - Build the `.app` bundle
  - Sign the `.app` with `rcodesign` in CI using a `.p12` from GitHub Secrets
  - Create a DMG wrapping `Astonia.app`
  - Sign, notarize, and staple the DMG via `indygreg/apple-code-sign-action@v1` + App Store Connect API key
  - Upload the final signed + notarized DMG as a release artifact

## Notes

- Local signing and CI signing now both go through `rcodesign`, so we can debug signing/notarization issues locally with the same toolchain.
- See a test release here: https://github.com/AstoniaCommunity/astonia_community_client/releases/tag/macos-build-test-xiii