### PR TITLE
The application window title depends on the DEVELOPER macro.

### DIFF
--- a/src/gui/gui_buttons.c
+++ b/src/gui/gui_buttons.c
@@ -895,9 +895,15 @@ static void update_window_title(void)
 
 	plrmn = mapmn(MAPDX / 2, MAPDY / 2);
 
-	sprintf(buf, "%s - Astonia 3 v%d.%d.%d - (%s:%u)",
+#ifdef DEVELOPER
+	sprintf(buf, "DEVELOPER %s - Astonia 3 v%d.%d.%d - (%s:%u)",
 	    (map[plrmn].cn && player[map[plrmn].cn].name[0]) ? player[map[plrmn].cn].name : "Someone",
 	    (VERSION >> 16) & 255, (VERSION >> 8) & 255, (VERSION) & 255, target_server, (unsigned int)target_port);
+#else
+	sprintf(buf, "%s - Astonia 3 v%d.%d.%d",
+	    (map[plrmn].cn && player[map[plrmn].cn].name[0]) ? player[map[plrmn].cn].name : "Someone",
+	    (VERSION >> 16) & 255, (VERSION >> 8) & 255, (VERSION) & 255);
+#endif
 	if (strcmp(title, buf)) {
 		strcpy(title, buf);
 		sdl_set_title(title);


### PR DESCRIPTION
[Remove IP info from Release build in game Title](https://github.com/AstoniaCommunity/astonia_community_client/issues/18)

If exists macro DEVELOPER, application title is
`DEVELOPER <name> Astonia 3 v<version> (<url>:<port>)`
 else
`<name> Astonia 3 v<version>`

