### PR TITLE
Switch statically known buffers to static alloc

### DIFF
--- a/src/game/render.c
+++ b/src/game/render.c
@@ -21,14 +21,20 @@
 #include "client/client.h"
 #include "sdl/sdl.h"
 
-RenderFont *fonta_shaded = NULL;
-RenderFont *fonta_framed = NULL;
+static RenderFont fonta_shaded_storage[128];
+RenderFont *fonta_shaded = fonta_shaded_storage;
+static RenderFont fonta_framed_storage[128];
+RenderFont *fonta_framed = fonta_framed_storage;
 
-RenderFont *fontb_shaded = NULL;
-RenderFont *fontb_framed = NULL;
+static RenderFont fontb_shaded_storage[128];
+RenderFont *fontb_shaded = fontb_shaded_storage;
+static RenderFont fontb_framed_storage[128];
+RenderFont *fontb_framed = fontb_framed_storage;
 
-RenderFont *fontc_shaded = NULL;
-RenderFont *fontc_framed = NULL;
+static RenderFont fontc_shaded_storage[128];
+RenderFont *fontc_shaded = fontc_shaded_storage;
+static RenderFont fontc_framed_storage[128];
+RenderFont *fontc_framed = fontc_framed_storage;
 
 // Global rendering offset for window scaling and positioning
 int x_offset, y_offset;
@@ -966,7 +972,7 @@ void render_create_font(void)
 	uint32_t *pixel;
 	int dx, dy;
 
-	if (fonta_shaded) {
+	if (fonta_shaded[0].raw) {
 		return;
 	}
 
@@ -995,18 +1001,12 @@ void render_create_font(void)
 #endif
 	}
 
-	fonta_shaded = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_shade_font(fonta, fonta_shaded);
-	fontb_shaded = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_shade_font(fontb, fontb_shaded);
-	fontc_shaded = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_shade_font(fontc, fontc_shaded);
 
-	fonta_framed = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_frame_font(fonta, fonta_framed);
-	fontb_framed = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_frame_font(fontb, fontb_framed);
-	fontc_framed = xmalloc(sizeof(RenderFont) * 128, MEM_GLOB);
 	create_frame_font(fontc, fontc_framed);
 }
 
@@ -1059,7 +1059,8 @@ struct letter {
 	unsigned char link;
 };
 
-struct letter *text = NULL;
+static struct letter text_storage[MAXTEXTLINES * MAXTEXTLETTERS];
+struct letter *text = text_storage;
 
 unsigned short palette[256];
 
@@ -1069,7 +1070,6 @@ unsigned short palette[256];
  */
 void render_init_text(void)
 {
-	text = xmalloc(sizeof(struct letter) * MAXTEXTLINES * MAXTEXTLETTERS, MEM_GLOB);
 	palette[0] = IRGB(31, 31, 31); // normal white text (talk, game messages)
 	palette[1] = IRGB(16, 16, 16); // dark gray text (now entering ...)
 	palette[2] = IRGB(16, 31, 16); // light green (normal chat)

--- a/src/gui/dots.c
+++ b/src/gui/dots.c
@@ -17,8 +17,10 @@
 
 extern int __textdisplay_sy;
 
-DOT *dot = NULL;
-BUT *but = NULL;
+static DOT dot_storage[MAX_DOT];
+DOT *dot = dot_storage;
+static BUT but_storage[MAX_BUT];
+BUT *but = but_storage;
 
 // dot and but helpers
 static void set_dot(int didx, int x, int y, int flags);
@@ -82,9 +84,6 @@ void dots_update(void)
 void init_dots(void)
 {
 	int i, x, y, xc, yc;
-
-	// dots
-	dot = xmalloc(MAX_DOT * sizeof(DOT), MEM_GUI);
 
 	// top left, bottom right of screen
 	set_dot(DOT_TL, 0, 0, 0);
@@ -193,9 +192,6 @@ void init_dots(void)
 
 	// tutor window
 	dots_update();
-
-	// buts
-	but = xmalloc(MAX_BUT * sizeof(BUT), MEM_GUI);
 
 	set_but(BUT_MAP, XRES / 2, YRES / 2, 0, BUTF_NOHIT);
 

--- a/src/gui/gui_core.c
+++ b/src/gui/gui_core.c
@@ -236,10 +236,6 @@ int main_init(void)
 
 void main_exit(void)
 {
-	xfree(dot);
-	dot = NULL;
-	xfree(but);
-	but = NULL;
 	xfree(skltab);
 	skltab = NULL;
 	skltab_max = 0;

--- a/src/sdl/sdl_core.c
+++ b/src/sdl/sdl_core.c
@@ -66,7 +66,8 @@ static SDL_atomic_t pre_quit;
 static SDL_Thread **prethreads = NULL;
 
 // Image loading state machine (shared with sdl_image.c)
-int *sdli_state = NULL;
+static int sdli_state_storage[MAXSPRITE];
+int *sdli_state = sdli_state_storage;
 
 void sdl_dump(FILE *fp)
 {
@@ -100,7 +101,6 @@ void sdl_dump(FILE *fp)
 
 int sdl_init(int width, int height, char *title)
 {
-	size_t len;
 	int i;
 	SDL_DisplayMode DM;
 
@@ -140,12 +140,6 @@ int sdl_init(int width, int height, char *title)
 		return 0;
 	}
 
-	len = sizeof(struct sdl_image) * MAXSPRITE;
-	sdli = xmalloc(len, MEM_SDL_BASE);
-	if (!sdli) {
-		return fail("Out of memory in sdl_init");
-	}
-
 	sdlt_cache = xmalloc((size_t)MAX_TEXHASH * sizeof(int), MEM_SDL_BASE);
 	if (!sdlt_cache) {
 		return fail("Out of memory in sdl_init");
@@ -158,15 +152,6 @@ int sdl_init(int width, int height, char *title)
 	sdlt = xmalloc((size_t)MAX_TEXCACHE * sizeof(struct sdl_texture), MEM_SDL_BASE);
 	if (!sdlt) {
 		return fail("Out of memory in sdl_init");
-	}
-
-	// Initialize sdli_state array for image loading state machine
-	sdli_state = xmalloc(MAXSPRITE * sizeof(int), MEM_SDL_BASE);
-	if (!sdli_state) {
-		return fail("Out of memory in sdl_init");
-	}
-	for (i = 0; i < MAXSPRITE; i++) {
-		sdli_state[i] = 0; // IMG_UNLOADED
 	}
 
 	for (i = 0; i < MAX_TEXCACHE; i++) {
@@ -513,11 +498,6 @@ void sdl_exit(void)
 	if (premutex) {
 		SDL_DestroyMutex(premutex);
 		premutex = NULL;
-	}
-
-	if (sdli_state) {
-		xfree(sdli_state);
-		sdli_state = NULL;
 	}
 
 	if (game_options & GO_SOUND) {

--- a/src/sdl/sdl_texture.c
+++ b/src/sdl/sdl_texture.c
@@ -26,7 +26,8 @@ int sdlt_best, sdlt_last;
 int *sdlt_cache;
 
 // Image cache
-struct sdl_image *sdli = NULL;
+static struct sdl_image sdli_storage[MAXSPRITE];
+struct sdl_image *sdli = sdli_storage;
 
 // Statistics
 int texc_used = 0;


### PR DESCRIPTION
These buffers have fixed sizes known at compilation time, so we can avoid dynamic allocation entirely. This makes memory usage more predictable, doesn't require we remember to correctly free the data, and removes allocation overhead for these buffers.