### PR TITLE
Fixes to get the sample amod to compile again.

### DIFF
--- a/src/amod/amod.h
+++ b/src/amod/amod.h
@@ -197,8 +197,8 @@ DLL_EXPORT int get_chr_height(unsigned int csprite);
 DLL_EXPORT unsigned int trans_asprite(map_index_t mn, unsigned int sprite, tick_t attick, unsigned char *pscale,
     unsigned char *pcr, unsigned char *pcg, unsigned char *pcb, unsigned char *plight, unsigned char *psat,
     unsigned short *pc1, unsigned short *pc2, unsigned short *pc3, unsigned short *pshine);
-DLL_EXPORT int trans_charno(int csprite, int *pscale, int *pcr, int *pcg, int *pcb, int *plight, int *psat, int *pc1, int *pc2,
-    int *pc3, int *pshine, int attick);
+DLL_EXPORT int trans_charno(int csprite, int *pscale, int *pcr, int *pcg, int *pcb, int *plight, int *psat, int *pc1,
+    int *pc2, int *pc3, int *pshine, int attick);
 DLL_EXPORT int get_player_sprite(int nr, int zdir, int action, int step, int duration, int attick);
 DLL_EXPORT void trans_csprite(int mn, struct map *cmap, int attick);
 DLL_EXPORT int get_lay_sprite(int sprite, int lay);

--- a/src/dll.h
+++ b/src/dll.h
@@ -1,7 +1,7 @@
 #ifdef _WIN32
 // On Windows, always use __declspec for DLL exports (works with all compilers)
 #define DLL_EXPORT __declspec(dllexport)
-//#define DLL_IMPORT __declspec(dllimport)
+// #define DLL_IMPORT __declspec(dllimport)
 #define DLL_IMPORT
 #else
 // On Unix-like systems, use visibility attributes for GCC/Clang


### PR DESCRIPTION
Apparently clang is a bit more picky about the _dllexport_ being set consistently. I added the missing tags.

_dllimport_ however does not appear to be needed anymore, and triggers a warning. I've removed it from the define in dll.h. Not sure if this is the best solution, but it compiles and runs.
