### PR TITLE
Fix strcasestr availability on Ubuntu 22

### DIFF
--- a/src/gui/cmd.c
+++ b/src/gui/cmd.c
@@ -6,6 +6,7 @@
  * Processes key strokes and executes commands.
  */
 
+#define _GNU_SOURCE // needs to be defined so that clang gives us the declaration of strcasestr reliably
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Just a one-line-fix to make it compile on Ubuntu 22: strcasestr() is a GNU enhancement and clang does not always provide it unless you ask nicely.