### PR TITLE
Set absolute path for 'find' in a bunch of scripts...

### DIFF
--- a/scripts/check-format-c.sh
+++ b/scripts/check-format-c.sh
@@ -6,6 +6,7 @@ set -e
 # For local development, use check-format.sh instead (checks all languages)
 # Exit code 0 = all formatted correctly, 1 = formatting issues found
 
+FIND="/usr/bin/find"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
@@ -45,7 +46,7 @@ fi
 rm -f "$LOG_DIR/clang-format.log"
 C_FORMAT_FAILED=0
 
-for file in $(find src -type f \( -name "*.c" -o -name "*.h" \)); do
+for file in $($FIND src -type f \( -name "*.c" -o -name "*.h" \)); do
     if ! $CLANG_FORMAT --dry-run -Werror --style=file "$file" 2>/dev/null; then
         if [ $C_FORMAT_FAILED -eq 0 ]; then
             echo "ERROR: The following files need formatting:" | tee "$LOG_DIR/clang-format.log"

--- a/scripts/check-static-analysis.sh
+++ b/scripts/check-static-analysis.sh
@@ -6,6 +6,7 @@ set -e
 # Used by both CI pipeline and local development
 # Exit code 0 = no issues, 1 = issues found
 
+FIND="/usr/bin/find"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
@@ -46,7 +47,7 @@ else
         FAILED=1
     else
         echo "Running clang-tidy analysis..."
-        find src -type f -name "*.c" -print0 | \
+        $FIND src -type f -name "*.c" -print0 | \
             xargs -0 clang-tidy > "$LOG_DIR/clang-tidy.log" 2>&1 || true
 
         if grep -qE "warning:|error:" "$LOG_DIR/clang-tidy.log"; then

--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -5,6 +5,7 @@ set -e
 # Used by both CI pipeline and local development (make lint)
 # Applies formatting fixes automatically
 
+FIND="/usr/bin/find"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
@@ -37,7 +38,7 @@ if [ "$CLANG_FORMAT_VERSION" != "21" ]; then
 fi
 
 # Format all C/H files
-find src -type f \( -name "*.c" -o -name "*.h" \) -exec $CLANG_FORMAT -i --style=file {} \;
+$FIND src -type f \( -name "*.c" -o -name "*.h" \) -exec $CLANG_FORMAT -i --style=file {} \;
 echo "  ✓ C code formatted"
 echo ""
 

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -4,6 +4,8 @@ set -e
 # Script to run clang-tidy with proper compilation database
 # This ensures clang-tidy knows about all includes, flags, and defines
 
+FIND="/usr/bin/find"
+
 echo "=== Clang-Tidy Runner ==="
 echo ""
 
@@ -32,12 +34,12 @@ MODE="${1:-check}"
 case "$MODE" in
     check)
         echo "Running clang-tidy in check mode (no fixes)..."
-        find src -type f -name "*.c" -print0 | \
+        $FIND src -type f -name "*.c" -print0 | \
             xargs -0 clang-tidy -p . $CHECKS_ARG
         ;;
     fix)
         echo "Running clang-tidy in fix mode..."
-        find src -type f -name "*.c" -print0 | \
+        $FIND src -type f -name "*.c" -print0 | \
             xargs -0 clang-tidy -p . -fix-errors $CHECKS_ARG
         ;;
     regen)

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -4,6 +4,8 @@ set -e
 # Code coverage analysis script
 # Generates HTML coverage reports showing which code paths are executed
 
+FIND="/usr/bin/find"
+
 echo "=== Code Coverage Analysis ==="
 echo ""
 
@@ -22,7 +24,7 @@ shift 2>/dev/null || true
 
 # Clean previous coverage data
 echo "Cleaning previous coverage data..."
-find . -name "*.gcda" -delete 2>/dev/null || true
+$FIND . -name "*.gcda" -delete 2>/dev/null || true
 rm -rf coverage-html 2>/dev/null || true
 
 echo "Running coverage-instrumented binary: $BINARY $@"


### PR DESCRIPTION
... so that Windows 'find' does not get called instead.