### PR TITLE
Fix: Make 'Use With' take priority over 'Give'

### DIFF
--- a/src/gui/gui_buttons.c
+++ b/src/gui/gui_buttons.c
@@ -1012,7 +1012,8 @@ void calculate_lcmd_logic(void)
 		if (chrsel != MAXMN && !vk_item && vk_char && !csprite) {
 			lcmd = CMD_CHR_ATTACK;
 		}
-		if (chrsel != MAXMN && !vk_item && vk_char && csprite) {
+		// Only set Give if we haven't already set Use With (Use With trumps Give)
+		if (chrsel != MAXMN && !vk_item && vk_char && csprite && lcmd != CMD_ITM_USE_WITH) {
 			lcmd = CMD_CHR_GIVE;
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes item interaction priority so "Use With" actions take precedence over "Give"
- Improves usability when interacting with items near NPCs

## Changes
- Reordered action priority checks to prefer "Use With" over "Give"

---
*Extracted from larger PR for focused review*