### PR TITLE
Fix: Pentagram text overlap with action bar

### DIFF
--- a/src/game/game_display.c
+++ b/src/game/game_display.c
@@ -1371,7 +1371,8 @@ void display_pents(void)
 		default:
 			continue;
 		}
-		if (context_action_enabled()) {
+		// Offset pent text if action bar UI exists (regardless of whether icons are visible)
+		if (game_options & GO_ACTION) {
 			yoff = 30;
 		} else {
 			yoff = 0;


### PR DESCRIPTION
## Summary
- Fixes visual overlap between pentagram record text and the action bar
- Improves UI clarity when pentagram information is displayed

## Changes
- Adjusted positioning/visibility of pentagram text elements

---
*Extracted from larger PR for focused review*