### PR TITLE
Fix: Shadow font rendering gaps at 2X scale

### DIFF
--- a/src/game/render.c
+++ b/src/game/render.c
@@ -1297,12 +1297,19 @@ static unsigned char *render_create_rawrun(char letter[64][64])
 static void create_shade_font(RenderFont *src, RenderFont *dst)
 {
 	char letter[64][64];
-	int c;
+	int c, x, y;
 
 	for (c = 0; c < 128; c++) {
 		bzero(letter, sizeof(letter));
-		render_create_letter(src[c].raw, sdl_scale * 4, sdl_scale * 5, 2, letter);
-		render_create_letter(src[c].raw, sdl_scale * 5, sdl_scale * 4, 2, letter);
+		// Create shadow in a diagonal pattern without gaps
+		for (y = 0; y <= sdl_scale; y++) {
+			for (x = 0; x <= sdl_scale; x++) {
+				if (x > 0 || y > 0) { // Don't draw at (0,0)
+					render_create_letter(src[c].raw, sdl_scale * 4 + x, sdl_scale * 4 + y, 2, letter);
+				}
+			}
+		}
+		// Draw the actual character on top
 		render_create_letter(src[c].raw, sdl_scale * 4, sdl_scale * 4, 1, letter);
 		dst[c].raw = render_create_rawrun(letter);
 		dst[c].dim = src[c].dim;


### PR DESCRIPTION
## Summary
- Fixes visual gaps in shadow/shaded text when using 2X scaling
- Improves text readability at higher resolutions

## Changes
- Adjusted shadow font rendering to eliminate gaps at 2X scale

---
*Extracted from larger PR for focused review*