### PR TITLE
Feature: Multi-monitor support via command line option

### DIFF
--- a/src/game/main.c
+++ b/src/game/main.c
@@ -287,6 +287,7 @@ DLL_EXPORT char server_url[256];
 DLL_EXPORT int server_port = 0;
 DLL_EXPORT int want_width = 0;
 DLL_EXPORT int want_height = 0;
+DLL_EXPORT int want_monitor = 0; // Monitor number for multi-monitor support (0=default)
 
 int parse_args(int argc, char *argv[])
 {
@@ -428,6 +429,19 @@ int parse_args(int argc, char *argv[])
 					sv_ver = 30;
 				} else {
 					sv_ver = (int)v;
+				}
+			}
+			break;
+		case 'n': // -n monitor number for multi-monitor support
+			if (!val && i + 1 < argc) {
+				val = argv[++i];
+			}
+			if (val) {
+				long n = strtol(val, &end, 10);
+				if (n < INT_MIN || n > INT_MAX) {
+					want_monitor = 0;
+				} else {
+					want_monitor = (int)n;
 				}
 			}
 			break;
@@ -640,7 +654,7 @@ int main(int argc, char *argv[])
 	determine_resolution();
 
 	sprintf(buf, "Astonia 3 v%d.%d.%d", (VERSION >> 16) & 255, (VERSION >> 8) & 255, (VERSION) & 255);
-	if (!sdl_init(want_width, want_height, buf)) {
+	if (!sdl_init(want_width, want_height, buf, want_monitor)) {
 		render_exit();
 		return -1;
 	}

--- a/src/sdl/sdl.h
+++ b/src/sdl/sdl.h
@@ -60,7 +60,7 @@ void sdl_capture_mouse(int flag);
 int sdl_tx_load(unsigned int sprite, signed char sink, unsigned char freeze, unsigned char scale, char cr, char cg,
     char cb, char light, char sat, int c1, int c2, int c3, int shine, char ml, char ll, char rl, char ul, char dl,
     const char *text, int text_color, int text_flags, void *text_font, int checkonly, int preload);
-int sdl_init(int width, int height, char *title);
+int sdl_init(int width, int height, char *title, int monitor);
 void sdl_exit(void);
 void sdl_loop(void);
 int sdl_clear(void);

--- a/src/sdl/sdl_core.c
+++ b/src/sdl/sdl_core.c
@@ -89,9 +89,12 @@ void sdl_dump(FILE *fp)
 
 // #define GO_DEFAULTS (GO_CONTEXT|GO_ACTION|GO_BIGBAR|GO_PREDICT|GO_SHORT|GO_MAPSAVE|GO_NOMAP)
 
-int sdl_init(int width, int height, char *title)
+int sdl_init(int width, int height, char *title, int monitor)
 {
 	int i;
+	int num_displays;
+	SDL_DisplayID *displays;
+	SDL_DisplayID display_id;
 
 	if (!SDL_Init(SDL_INIT_VIDEO | ((game_options & GO_SOUND) ? SDL_INIT_AUDIO : 0))) {
 		fail("SDL_Init Error: %s", SDL_GetError());
@@ -100,7 +103,24 @@ int sdl_init(int width, int height, char *title)
 
 	SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 
-	SDL_DisplayID display_id = SDL_GetPrimaryDisplay();
+	// Get all available displays
+	displays = SDL_GetDisplays(&num_displays);
+	if (!displays || num_displays == 0) {
+		fail("SDL_GetDisplays Error: %s", SDL_GetError());
+		SDL_Quit();
+		return 0;
+	}
+
+	// Validate monitor number and select display
+	if (monitor < 0 || monitor >= num_displays) {
+		note("Invalid monitor %d, using default (0). Available monitors: %d", monitor, num_displays);
+		monitor = 0;
+	} else if (monitor > 0) {
+		note("Using monitor %d of %d available monitors", monitor, num_displays);
+	}
+	display_id = displays[monitor];
+	SDL_free(displays);
+
 	const SDL_DisplayMode *DM = SDL_GetCurrentDisplayMode(display_id);
 
 	if (!DM) {
@@ -114,7 +134,17 @@ int sdl_init(int width, int height, char *title)
 		height = DM->h;
 	}
 
+	// Create window and position on selected monitor
 	sdlwnd = SDL_CreateWindow(title, width, height, 0);
+	if (sdlwnd && monitor > 0) {
+		// Position window on the selected monitor
+		SDL_Rect display_bounds;
+		if (SDL_GetDisplayBounds(display_id, &display_bounds)) {
+			int x_pos = display_bounds.x + (DM->w - width) / 2;
+			int y_pos = display_bounds.y + (DM->h - height) / 2;
+			SDL_SetWindowPosition(sdlwnd, x_pos, y_pos);
+		}
+	}
 	if (!sdlwnd) {
 		fail("SDL_Init Error: %s", SDL_GetError());
 		SDL_Quit();


### PR DESCRIPTION
## Summary
- Adds multi-monitor support allowing users to specify which monitor to open the game window on

## Changes
- Added `-n <monitor_number>` command line option
- Added `want_monitor` global variable (default 0)
- Modified `sdl_init()` to accept monitor parameter
- Window is positioned on the selected monitor
- Validates monitor number and falls back to default if invalid
- Uses SDL3 API (`SDL_GetDisplays`) for display enumeration

## Usage
```
-n 0  # Primary monitor (default)
-n 1  # Secondary monitor
-n 2  # Third monitor, etc.
```

The window will be centered on the selected monitor, making it easy to use the game on multi-monitor setups.

---
*Extracted from larger PR for focused review*