### PR TITLE
Feature: Space bar as stop key binding

### DIFF
--- a/src/gui/gui_input.c
+++ b/src/gui/gui_input.c
@@ -78,6 +78,16 @@ void gui_sdl_keyproc(SDL_Keycode wparam)
 		cmd_speed(2);
 		return;
 
+	case SDLK_SPACE:
+		// Space bar acts as stop key (like ESC but doesn't close UI)
+		// Only when not typing in command line (let text input handle it)
+		if (!context_key_isset()) {
+			cmd_stop();
+			context_stop();
+			cmd_reset();
+		}
+		return;
+
 	case SDLK_F8:
 		nocut ^= 1;
 		return;


### PR DESCRIPTION
## Summary
- Adds space bar as an alternative stop key (similar to ESC)
- Provides a more convenient way to stop character movement

## Changes
Space bar now:
- Stops current movement/action via `cmd_stop()`
- Stops context menu actions via `context_stop()`
- Resets command state via `cmd_reset()`

Unlike ESC, the space bar does **not** close any UI elements (quest window, help screen, etc.), making it useful for quickly stopping character movement without affecting the interface.

## Benefits
- More convenient stop key closer to movement keys (WASD or arrows)
- Faster reaction times for stopping movement
- Doesn't interfere with open UI panels

---
*Extracted from larger PR for focused review*