### PR TITLE
Feature: Mousewheel movement speed toggle option

### DIFF
--- a/src/astonia.h
+++ b/src/astonia.h
@@ -140,25 +140,26 @@ extern int quit;
 DLL_EXPORT extern int frames_per_second;
 extern char *localdata;
 
-#define GO_DARK     (1ull << 0) // Dark GUI by Tegra
-#define GO_CONTEXT  (1ull << 1) // Right-Click Context Menu
-#define GO_ACTION   (1ull << 2) // Action Bar and Key Bindings
-#define GO_SMALLBOT (1ull << 3) // Smaller Bottom Window
-#define GO_SMALLTOP (1ull << 4) // Smaller Top Window
-#define GO_BIGBAR   (1ull << 5) // Show big health bar etc.
-#define GO_SOUND    (1ull << 6) // Enable sound
-#define GO_LARGE    (1ull << 7) // Use large font
-#define GO_FULL     (1ull << 8) // Use true full screen mode
-#define GO_WHEEL    (1ull << 9) // Use old mouse wheel logic
-#define GO_PREDICT  (1ull << 10) // Process some commands early for faster responses (prefetch() instead of process())
-#define GO_SHORT    (1ull << 11) // Less command delay, more stutter in animations
-#define GO_APPDATA  (1ull << 12) // Use Windows %appdata% to store configuration and logs
-#define GO_MAPSAVE  (1ull << 13) // Load/Save minimap data
-#define GO_LIGHTER  (1ull << 14) // Gamma increase, sort of
-#define GO_LIGHTER2 (1ull << 15) // More gamma increase
-#define GO_TINYTOP  (1ull << 16) // Slide out top only when mouse cursor is over window border
-#define GO_LOWLIGHT (1ull << 17) // Simplify Light calculations for slow CPUs
-#define GO_NOMAP    (1ull << 18) // Disable minimap completely
+#define GO_DARK       (1ull << 0) // Dark GUI by Tegra
+#define GO_CONTEXT    (1ull << 1) // Right-Click Context Menu
+#define GO_ACTION     (1ull << 2) // Action Bar and Key Bindings
+#define GO_SMALLBOT   (1ull << 3) // Smaller Bottom Window
+#define GO_SMALLTOP   (1ull << 4) // Smaller Top Window
+#define GO_BIGBAR     (1ull << 5) // Show big health bar etc.
+#define GO_SOUND      (1ull << 6) // Enable sound
+#define GO_LARGE      (1ull << 7) // Use large font
+#define GO_FULL       (1ull << 8) // Use true full screen mode
+#define GO_WHEEL      (1ull << 9) // Use old mouse wheel logic
+#define GO_PREDICT    (1ull << 10) // Process some commands early for faster responses (prefetch() instead of process())
+#define GO_SHORT      (1ull << 11) // Less command delay, more stutter in animations
+#define GO_APPDATA    (1ull << 12) // Use Windows %appdata% to store configuration and logs
+#define GO_MAPSAVE    (1ull << 13) // Load/Save minimap data
+#define GO_LIGHTER    (1ull << 14) // Gamma increase, sort of
+#define GO_LIGHTER2   (1ull << 15) // More gamma increase
+#define GO_TINYTOP    (1ull << 16) // Slide out top only when mouse cursor is over window border
+#define GO_LOWLIGHT   (1ull << 17) // Simplify Light calculations for slow CPUs
+#define GO_NOMAP      (1ull << 18) // Disable minimap completely
+#define GO_WHEELSPEED (1ull << 19) // Mouse wheel toggles movement speed (fast/normal/stealth)
 
 #define GO_NOTSET (1ull << 63) // No -o given on command line
 

--- a/src/gui/gui_input.c
+++ b/src/gui/gui_input.c
@@ -465,6 +465,35 @@ void gui_sdl_mouseproc(float x, float y, int what)
 			break;
 		}
 
+		if (game_options & GO_WHEELSPEED) {
+			// Mousewheel toggles movement speed mode
+			// pspeed: 0=normal, 1=fast, 2=stealth
+			// cmd_speed: 0=normal, 1=fast, 2=stealth
+			while (delta > 0) {
+				// Scroll up: cycle through normal->fast->stealth->normal
+				if (pspeed == 0) {
+					cmd_speed(1); // normal to fast
+				} else if (pspeed == 1) {
+					cmd_speed(2); // fast to stealth
+				} else if (pspeed == 2) {
+					cmd_speed(0); // stealth to normal
+				}
+				delta--;
+			}
+			while (delta < 0) {
+				// Scroll down: cycle through normal->stealth->fast->normal
+				if (pspeed == 0) {
+					cmd_speed(2); // normal to stealth
+				} else if (pspeed == 2) {
+					cmd_speed(1); // stealth to fast
+				} else if (pspeed == 1) {
+					cmd_speed(0); // fast to normal
+				}
+				delta++;
+			}
+			break;
+		}
+
 		if (game_options & GO_WHEEL) {
 			while (delta > 0) {
 				vk_special_inc();


### PR DESCRIPTION
## Summary
- Adds optional mousewheel movement speed toggle feature
- Allows quick speed changes without moving hands from mouse

## Changes
- New `GO_WHEELSPEED` option (bit 19, value 524288)
- Scroll up: cycles Normal -> Fast -> Stealth -> Normal
- Scroll down: cycles Normal -> Stealth -> Fast -> Normal
- Only active when mouse is not over UI areas (skills, chat, inventory)
- Does not interfere with existing `GO_WHEEL` functionality

## Usage
To enable mousewheel speed toggle, add `GO_WHEELSPEED` (524288) to your game options:
```
-o <current_options + 524288>
```

This makes movement speed changes quick and intuitive without moving hands from the mouse.

---
*Extracted from larger PR for focused review*