### PR TITLE
Fix item/character highlighting when holding action keys

### DIFF
--- a/src/gui/context.c
+++ b/src/gui/context.c
@@ -459,7 +459,7 @@ void context_keydown(SDL_Keycode key)
 	}
 
 	// ignore key-down while over action bar
-	if (actsel != MAXMN) {
+	if (actsel != -1) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Fixes the broken item/character highlighting when holding keys like 'l' (look) or 'g' (give)
- The condition `actsel != MAXMN` was incorrect - `actsel` is an `int` using -1 for no selection, while `MAXMN` is a large constant
- Changed to `actsel != -1` which correctly checks if mouse is over the action bar

Fixes #67