### PR TITLE
Fix minimap buffer issues causing unexpected resets

### DIFF
--- a/src/gui/minimap.c
+++ b/src/gui/minimap.c
@@ -132,7 +132,7 @@ void minimap_update(void)
 			}
 		}
 	}
-	if (rewrite_cnt > 4) {
+	if (rewrite_cnt > 8) {
 		memset(_mmap, 0, sizeof(_mmap));
 		update1 = update2 = 1;
 		note("MAP CHANGED: %d", rewrite_cnt);
@@ -507,7 +507,7 @@ void minimap_compact(void)
 			if (map_compare(tmap, xmap)) {
 				map_merge(tmap, xmap);
 				filename = mapname(i);
-				fp = fopen(filename, "rb");
+				fp = fopen(filename, "wb");
 				if (!fp) {
 					continue;
 				}


### PR DESCRIPTION
## Summary
Two fixes for minimap stability:

1. **Fix file mode in `minimap_compact()`**: Changed `fopen` from `"rb"` to `"wb"` when writing merged map data. The function was silently failing to save merged maps because it tried to write to a read-only file handle.

2. **Increase `rewrite_cnt` threshold from 4 to 8**: The previous threshold was too aggressive and could trigger false map resets when multiple tiles changed state (e.g., doors opening, NPCs moving). This caused players to lose explored minimap data unexpectedly.

Fixes #55