### PR TITLE
Feature: Add optional pre-commit hook for auto-formatting

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Pre-commit hook: Auto-format code and re-stage changes
+#
+# Install with: scripts/install-hooks.sh
+#
+
+# Get list of staged files (excluding deleted files)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=d)
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+# Check if any C or Rust files are staged
+C_FILES=$(echo "$STAGED_FILES" | grep -E '\.(c|h)$' || true)
+RUST_FILES=$(echo "$STAGED_FILES" | grep -E '\.rs$' || true)
+
+if [ -z "$C_FILES" ] && [ -z "$RUST_FILES" ]; then
+    exit 0
+fi
+
+echo "Running auto-formatter..."
+
+# Run the linter/formatter
+make lint > /dev/null 2>&1
+
+# Re-stage any files that were modified by the formatter
+if [ -n "$C_FILES" ]; then
+    for file in $C_FILES; do
+        if [ -f "$file" ]; then
+            git add "$file"
+        fi
+    done
+fi
+
+if [ -n "$RUST_FILES" ]; then
+    for file in $RUST_FILES; do
+        if [ -f "$file" ]; then
+            git add "$file"
+        fi
+    done
+fi
+
+echo "Auto-format complete."
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Install git hooks for development
+#
+# Usage: scripts/install-hooks.sh
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_SRC="$SCRIPT_DIR/hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+echo "Installing git hooks..."
+
+# Ensure we're in a git repository
+if [ ! -d "$REPO_ROOT/.git" ]; then
+    echo "Error: Not a git repository"
+    exit 1
+fi
+
+# Install pre-commit hook
+if [ -f "$HOOKS_SRC/pre-commit" ]; then
+    cp "$HOOKS_SRC/pre-commit" "$HOOKS_DST/pre-commit"
+    chmod +x "$HOOKS_DST/pre-commit"
+    echo "  ✓ Installed pre-commit hook (auto-formats code on commit)"
+fi
+
+echo ""
+echo "Done! Hooks installed successfully."
+echo ""
+echo "The pre-commit hook will automatically run 'make lint' and"
+echo "re-stage formatted files before each commit."
+echo ""
+echo "To bypass the hook for a single commit, use: git commit --no-verify"


### PR DESCRIPTION
## Summary

Adds an optional pre-commit hook that automatically formats code before each commit.

## Files Added

- `scripts/hooks/pre-commit` - The hook script that runs `make lint` and re-stages formatted files
- `scripts/install-hooks.sh` - Installer script for developers

## Usage

```bash
# Install the hook
scripts/install-hooks.sh

# Bypass for a single commit (if needed)
git commit --no-verify
```

## Behavior

When installed, the hook will:
1. Check if any C (`.c`, `.h`) or Rust (`.rs`) files are staged
2. Run `make lint` to auto-format the code
3. Re-stage any files that were modified by the formatter
4. Allow the commit to proceed

This is opt-in - developers choose whether to install the hook.