### PR TITLE
Fix: Export sprite_config_load functions for mod use

### DIFF
--- a/src/game/sprite_config.c
+++ b/src/game/sprite_config.c
@@ -579,7 +579,7 @@ void sprite_config_shutdown(void)
 	}
 }
 
-int sprite_config_load_characters(const char *path)
+DLL_EXPORT int sprite_config_load_characters(const char *path)
 {
 	if (init_tables() < 0) {
 		return -1;
@@ -622,7 +622,7 @@ int sprite_config_load_characters(const char *path)
 	return count;
 }
 
-int sprite_config_load_animated(const char *path)
+DLL_EXPORT int sprite_config_load_animated(const char *path)
 {
 	if (init_tables() < 0) {
 		return -1;
@@ -1166,7 +1166,7 @@ static int parse_sprite_metadata(cJSON *item, SpriteMetadata *m)
 	return 0;
 }
 
-int sprite_config_load_metadata(const char *path)
+DLL_EXPORT int sprite_config_load_metadata(const char *path)
 {
 	if (init_metadata_table() < 0) {
 		return -1;

--- a/src/game/sprite_config.h
+++ b/src/game/sprite_config.h
@@ -175,7 +175,7 @@ void sprite_config_shutdown(void);
  * path: Path to JSON file
  * Returns: Number of variants loaded, or -1 on error
  */
-int sprite_config_load_characters(const char *path);
+DLL_EXPORT int sprite_config_load_characters(const char *path);
 
 /*
  * Load animated variants from a JSON file.
@@ -184,7 +184,7 @@ int sprite_config_load_characters(const char *path);
  * path: Path to JSON file
  * Returns: Number of variants loaded, or -1 on error
  */
-int sprite_config_load_animated(const char *path);
+DLL_EXPORT int sprite_config_load_animated(const char *path);
 
 /*
  * Load variants from a JSON buffer (for future server-sent config).
@@ -260,7 +260,7 @@ void sprite_config_get_stats(size_t *char_count, size_t *anim_count);
  * path: Path to JSON file
  * Returns: Number of metadata entries loaded, or -1 on error
  */
-int sprite_config_load_metadata(const char *path);
+DLL_EXPORT int sprite_config_load_metadata(const char *path);
 
 /*
  * Look up sprite metadata by ID.


### PR DESCRIPTION
Adds `DLL_EXPORT` to sprite_config load functions so mods can call them from `amod_sprite_config()`:

- `sprite_config_load_characters()`
- `sprite_config_load_animated()`
- `sprite_config_load_metadata()`