### PR TITLE
Fix release pipeline: restore Git LFS checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Get week of year
         id: week
@@ -358,6 +360,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install dependencies
         run: |
@@ -504,6 +508,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Build AppImage
         run: make appimage


### PR DESCRIPTION
## Problem

Release artifacts since v1.1.0 are missing game assets because the `lfs: true` option was accidentally removed from checkout steps during the SDL2→SDL3 migration.

## Root Cause

In the SDL3 migration commit, the checkout steps were modified and `lfs: true` was removed from:
- `build-linux-release`
- `build-macos-release`
- `build-appimage-release`

Only `build-windows-release` retained the LFS option.

## Fix

Restores `lfs: true` to all affected checkout steps so LFS-tracked files (game assets) are properly downloaded during release builds.

## Affected Versions
- v1.1.0 and later releases are affected
- v1.0.0 was the last working release