### PR TITLE
Client/Server Protocol Cleanup

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -58,8 +58,6 @@ uint64_t tick_receive_interval = 0; // Time between server tick batch arrivals (
 static struct queue queue[Q_SIZE];
 int q_in, q_out, q_size;
 
-double server_cycles;
-
 static size_t ticksize;
 static size_t inused;
 static size_t indone;
@@ -142,8 +140,6 @@ void bzero_client(int part)
 
 		bzero(queue, sizeof(queue));
 		q_in = q_out = q_size = 0;
-
-		server_cycles = 0;
 
 		zsinit = 0;
 		bzero(&zs, sizeof(zs));

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -585,7 +585,6 @@ void cl_ticker(void);
 int close_client(void);
 int is_char_ceffect(int type);
 
-extern double server_cycles;
 extern int change_area;
 extern int login_done;
 extern unsigned int unique;

--- a/src/client/client_private.h
+++ b/src/client/client_private.h
@@ -34,16 +34,16 @@
 #define SV_GOLD             30
 #define SV_LOOKINV          31
 #define SV_ITEMPRICE        32
-#define SV_CYCLES           33
+#define SV__FREE_FOR_USE1__ 33
 #define SV_CEFFECT          34
 #define SV_UEFFECT          35
 #define SV_REALTIME         36
 #define SV_SPEEDMODE        37
-#define SV_FIGHTMODE        38 // unused in vanilla server
+#define SV__FREE_FOR_USE2__ 38
 #define SV_CONTYPE          39
 #define SV_CONNAME          40
-#define SV_LS               41
-#define SV_CAT              42
+#define SV__FREE_FOR_USE3__ 41
+#define SV__FREE_FOR_USE4__ 42
 #define SV_LOGINDONE        43
 #define SV_SPECIAL          44
 #define SV_TELEPORT         45

--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -352,9 +352,6 @@ static void sv_speedmode(unsigned char *buf)
 	pspeed = buf[1];
 }
 
-// unused in vanilla server
-static void sv_fightmode(unsigned char *buf __attribute__((unused))) {}
-
 static void sv_setcitem(unsigned char *buf)
 {
 	csprite = load_u32(buf + 1);
@@ -882,15 +879,6 @@ static void sv_mil_exp(unsigned char *buf)
 	mil_exp = load_ulong(buf + 1);
 }
 
-static void sv_cycles(unsigned char *buf)
-{
-	uint32_t c;
-
-	c = load_ulong(buf + 1);
-
-	server_cycles = server_cycles * 0.99 + (double)c * 0.01;
-}
-
 static void sv_lookinv(unsigned char *buf)
 {
 	int n;
@@ -1176,10 +1164,6 @@ void process(unsigned char *buf, int size)
 				sv_lookinv(buf);
 				len = 17 + 12 * 4;
 				break;
-			case SV_CYCLES:
-				sv_cycles(buf);
-				len = 5;
-				break;
 			case SV_CEFFECT:
 				len = sv_ceffect(buf);
 				break;
@@ -1200,10 +1184,6 @@ void process(unsigned char *buf, int size)
 
 			case SV_SPEEDMODE:
 				sv_speedmode(buf);
-				len = 2;
-				break;
-			case SV_FIGHTMODE:
-				sv_fightmode(buf);
 				len = 2;
 				break;
 			case SV_LOGINDONE:
@@ -1423,9 +1403,6 @@ uint32_t prefetch(unsigned char *buf, int size)
 			case SV_LOOKINV:
 				len = 17 + 12 * 4;
 				break;
-			case SV_CYCLES:
-				len = 5;
-				break;
 			case SV_CEFFECT:
 				len = svl_ceffect(buf);
 				break;
@@ -1440,9 +1417,6 @@ uint32_t prefetch(unsigned char *buf, int size)
 				len = 5;
 				break;
 			case SV_SPEEDMODE:
-				len = 2;
-				break;
-			case SV_FIGHTMODE:
 				len = 2;
 				break;
 			case SV_LOGINDONE:


### PR DESCRIPTION
Removed

SV_CYCLES
SV_FIGHTMODE
SV_LS
SV_CAT

and a few lines of supporting code. None of them are used in the vanilla servers (and not, to my knowledge, by any currently running server).
