### PR TITLE
Fix chat scroll not working with wrapped text lines

### DIFF
--- a/src/game/render.c
+++ b/src/game/render.c
@@ -1689,6 +1689,7 @@ void render_add_text(char *ptr)
 				textdisplayline = (textdisplayline + 1) % MAXTEXTLINES;
 			}
 			textnextline = (textnextline + 1) % MAXTEXTLINES;
+			textlines++; // Count wrapped continuation lines for scroll logic
 			pos = textnextline * MAXTEXTLETTERS;
 			bzero(text + pos, sizeof(struct letter) * MAXTEXTLETTERS);
 			x = tmp;


### PR DESCRIPTION
## Summary
- Fixes chat scrolling not working when text lines wrap to multiple display lines
- Increments `textlines` when text wraps in `render_add_text()` so scroll logic correctly tracks actual display line count

## Root Cause
The scroll rewrite in ea3da69 assumed `textlines` equals the number of display lines, but `render_add_text()` only incremented `textlines` once per call, not for each wrapped continuation line.

Fixes #102