### PR TITLE
Fix sprite configuration mismatches with original C code

### DIFF
--- a/res/config/animated_variants.json
+++ b/res/config/animated_variants.json
@@ -52,7 +52,7 @@
       "base_sprite": 11127,
       "animation": {
         "type": "bidirectional",
-        "frames": 16,
+        "frames": 8,
         "divisor": 4
       }
     },
@@ -145,8 +145,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 31
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 14353,
@@ -156,8 +155,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 31
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 12164,
@@ -167,8 +165,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 5
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 12165,
@@ -178,8 +175,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 5
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 12166,
@@ -189,8 +185,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 5
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 14361,
@@ -200,8 +195,7 @@
         "type": "position_cycle",
         "frames": 8,
         "divisor": 5
-      },
-      "c3": 16384
+      }
     },
     {
       "id": 1024,
@@ -1537,9 +1531,11 @@
       "comment": "dungeon_walllight_se_on",
       "base_sprite": 20388,
       "animation": {
-        "type": "bidirectional",
-        "frames": 16,
-        "divisor": 10
+        "type": "random_offset",
+        "frames": 8,
+        "divisor": 10,
+        "random_range": 2,
+        "branches": [{"threshold": 15}]
       }
     },
     {
@@ -1547,9 +1543,11 @@
       "comment": "dungeon_walllight_sw_on",
       "base_sprite": 20397,
       "animation": {
-        "type": "bidirectional",
-        "frames": 16,
-        "divisor": 10
+        "type": "random_offset",
+        "frames": 8,
+        "divisor": 10,
+        "random_range": 2,
+        "branches": [{"threshold": 15}]
       }
     },
     {
@@ -1557,9 +1555,11 @@
       "comment": "dungeon_walllight_nw_on",
       "base_sprite": 20406,
       "animation": {
-        "type": "bidirectional",
-        "frames": 16,
-        "divisor": 10
+        "type": "random_offset",
+        "frames": 8,
+        "divisor": 10,
+        "random_range": 2,
+        "branches": [{"threshold": 15}]
       }
     },
     {
@@ -1567,9 +1567,11 @@
       "comment": "dungeon_walllight_ne_on",
       "base_sprite": 20415,
       "animation": {
-        "type": "bidirectional",
-        "frames": 16,
-        "divisor": 10
+        "type": "random_offset",
+        "frames": 8,
+        "divisor": 10,
+        "random_range": 2,
+        "branches": [{"threshold": 15}]
       }
     },
     {
@@ -1699,7 +1701,7 @@
       "animation": {
         "type": "position_cycle",
         "frames": 64,
-        "divisor": 1
+        "divisor": 2
       }
     },
     {
@@ -1708,7 +1710,7 @@
       "animation": {
         "type": "position_cycle",
         "frames": 64,
-        "divisor": 1
+        "divisor": 2
       }
     },
     {
@@ -1717,7 +1719,7 @@
       "animation": {
         "type": "position_cycle",
         "frames": 64,
-        "divisor": 1
+        "divisor": 2
       }
     },
     {
@@ -1933,7 +1935,7 @@
       "base_sprite": 50289,
       "animation": {
         "type": "bidirectional",
-        "frames": 16,
+        "frames": 8,
         "divisor": 2
       }
     },
@@ -1942,7 +1944,7 @@
       "base_sprite": 50297,
       "animation": {
         "type": "bidirectional",
-        "frames": 16,
+        "frames": 8,
         "divisor": 2
       }
     },
@@ -2007,7 +2009,8 @@
       "animation": {
         "type": "position_cycle",
         "frames": 8,
-        "divisor": 1
+        "divisor": 1,
+        "frame_step": 2
       }
     },
     {
@@ -2016,7 +2019,8 @@
       "animation": {
         "type": "position_cycle",
         "frames": 8,
-        "divisor": 1
+        "divisor": 1,
+        "frame_step": 2
       }
     },
     {
@@ -2030,7 +2034,7 @@
       "base_sprite": 51625,
       "animation": {
         "type": "bidirectional",
-        "frames": 10,
+        "frames": 5,
         "divisor": 2
       }
     },
@@ -2046,7 +2050,7 @@
       "base_sprite": 56002,
       "animation": {
         "type": "bidirectional",
-        "frames": 8,
+        "frames": 5,
         "divisor": 2
       }
     },

--- a/res/config/sprite_metadata.json
+++ b/res/config/sprite_metadata.json
@@ -1091,35 +1091,35 @@
     },
     {
       "id": 20163,
-      "cut_sprite": 40000
+      "cut_sprite": 40004
     },
     {
       "id": 20164,
-      "cut_sprite": 40000
+      "cut_sprite": 40005
     },
     {
       "id": 20165,
-      "cut_sprite": 40000
+      "cut_sprite": 40006
     },
     {
       "id": 20166,
-      "cut_sprite": 40000
+      "cut_sprite": 40007
     },
     {
       "id": 20167,
-      "cut_sprite": 40012
+      "cut_sprite": 40016
     },
     {
       "id": 20168,
-      "cut_sprite": 40012
+      "cut_sprite": 40017
     },
     {
       "id": 20169,
-      "cut_sprite": 40012
+      "cut_sprite": 40018
     },
     {
       "id": 20170,
-      "cut_sprite": 40012
+      "cut_sprite": 40019
     },
     {
       "id": 20195,
@@ -2869,7 +2869,7 @@
     },
     {
       "id": 50330,
-      "cut_sprite": 14305
+      "cut_sprite": 14323
     },
     {
       "id": 51005,
@@ -3001,23 +3001,23 @@
     },
     {
       "id": 59193,
-      "cut_sprite": 14092
+      "cut_sprite": 14096
     },
     {
       "id": 59484,
-      "cut_sprite": 15447
+      "cut_sprite": 15452
     },
     {
       "id": 59485,
-      "cut_sprite": 15486
+      "cut_sprite": 15487
     },
     {
       "id": 59486,
-      "cut_sprite": 15457
+      "cut_sprite": 15462
     },
     {
       "id": 59487,
-      "cut_sprite": 15488
+      "cut_sprite": 15489
     },
     {
       "id": 59790,


### PR DESCRIPTION
Fixes #116

## Summary
Verified sprite JSON configurations against original C code in `sprite.c` and fixed mismatches found.

## sprite_metadata.json
Window wall cut sprites had incorrect offsets:
- `20163-20166`: cut_sprite `40000` → `40004-40007`
- `20167-20170`: cut_sprite `40012` → `40016-40019`

Other cut sprite fixes:
- `50330`: `14305` → `14323`
- `59193`: `14092` → `14096`
- `59484-59487`: incorrect base offsets corrected

## animated_variants.json
- `26070/26170/26270`: divisor `1` → `2` (animation was running at double speed)
- `12163-12166, 14353, 14361`: removed `c3` color (was commented out in original C)
- `51600/51601`: added `frame_step: 2` (only even frames used)
- `56002`: frames `8` → `5` (bidirectional animation threshold)