### PR TITLE
Make macOS signing/DMG steps conditional on secret availability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Check signing availability
+        id: signing
+        run: |
+          if [ -n "$CERT" ]; then echo "available=true"; else echo "available=false"; fi >> $GITHUB_OUTPUT
+        env:
+          CERT: ${{ secrets.APPLE_CERT_P12 }}
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -423,58 +430,53 @@ jobs:
           strip bin/moac
           strip -x bin/libastonia_net.dylib
 
-      # Build unsigned .app bundle
       - name: Build .app bundle
+        if: steps.signing.outputs.available == 'true'
         run: make macos-appbundle
 
-      # Materialize the signing certificate from a base64-encoded secret
       - name: Install signing certificate
+        if: steps.signing.outputs.available == 'true'
         run: |
           mkdir -p certs
           echo "${{ secrets.APPLE_CERT_P12 }}" | base64 --decode > certs/dist.p12
 
-      # Materialize the App Store Connect API key file in ./private_keys
-      # File name must match the api_key (KEY_ID) used later.
       - name: Install App Store Connect API key
+        if: steps.signing.outputs.available == 'true'
         run: |
           mkdir -p private_keys
           echo '${{ secrets.APP_STORE_CONNECT_KEY }}' > "private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8"
 
       - name: Install App Store Connect API key JSON
+        if: steps.signing.outputs.available == 'true'
         run: |
           echo '${{ secrets.APP_STORE_CONNECT_KEY_JSON }}' > private_keys/appstore_key.json
 
-      - name: Rename app with to tmp name
-        run: |
-          mv distrib/Astonia.app distrib/Astonia-unsigned.app
+      - name: Rename app to tmp name
+        if: steps.signing.outputs.available == 'true'
+        run: mv distrib/Astonia.app distrib/Astonia-unsigned.app
 
-      # 1) Sign app bundle
       - name: Sign Astonia.app
+        if: steps.signing.outputs.available == 'true'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: distrib/Astonia-unsigned.app
           output_path: distrib/Astonia.app
-
-          # Code signing certificate
           p12_file: certs/dist.p12
           p12_password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
-
           notarize: false
           staple: false
-
           rcodesign_version: 0.29.0
-
-          # Extra arguments passed directly to `rcodesign sign`
           sign_args: |
             --binary-identifier
             com.prismaphonic.astonia
             --for-notarization
 
       - name: Remove unsigned app bundle
+        if: steps.signing.outputs.available == 'true'
         run: rm -rf distrib/Astonia-unsigned.app
 
-      # 2) Create an unsigned DMG wrapping the notarized .app
-      - name: Create unsigned DMG from notarized app
+      - name: Create unsigned DMG from signed app
+        if: steps.signing.outputs.available == 'true'
         run: |
           cd distrib
           hdiutil create \
@@ -486,23 +488,17 @@ jobs:
           cd ..
           ls -lh distrib/Astonia-macOS-unsigned.dmg
 
-      # 3) Sign + notarize + staple the DMG
       - name: Sign, notarize, and staple DMG
+        if: steps.signing.outputs.available == 'true'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: distrib/Astonia-macOS-unsigned.dmg
           output_path: distrib/Astonia-macOS.dmg
-
-          # Code signing certificate
           p12_file: certs/dist.p12
           p12_password: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
-
           rcodesign_version: 0.29.0
-
           sign_args: |
             --for-notarization
-
-          # Notarization
           notarize: true
           staple: true
           app_store_connect_api_key_json_file: private_keys/appstore_key.json
@@ -510,9 +506,11 @@ jobs:
           app_store_connect_api_key: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
 
       - name: Remove unsigned DMG
+        if: steps.signing.outputs.available == 'true'
         run: rm -f distrib/Astonia-macOS-unsigned.dmg
 
       - name: Upload signed DMG
+        if: steps.signing.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg
@@ -569,6 +567,7 @@ jobs:
 
       - name: Download macOS DMG
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: macos-dmg
           path: .
@@ -595,7 +594,7 @@ jobs:
           sha256sum linux_client.tar.gz > checksums.txt
           sha256sum windows_client.zip >> checksums.txt
           sha256sum astonia-client.AppImage >> checksums.txt
-          sha256sum Astonia-macOS.dmg >> checksums.txt
+          [ -f Astonia-macOS.dmg ] && sha256sum Astonia-macOS.dmg >> checksums.txt || true
           sha256sum mod-sdk.zip >> checksums.txt
 
       - name: Create Release


### PR DESCRIPTION
Release workflow currently fails on forks because the macOS signing steps blow up when Apple certificates aren't configured.

This adds a check step early in the macOS build job that tests if APPLE_CERT_P12 exists and sets an output flag. All signing/notarization/DMG steps are gated behind that flag. The DMG download in create-release uses continue-on-error and the checksum handles the missing file gracefully.

On upstream nothing changes. On forks without Apple certs, signing is skipped and the release is created without a DMG.